### PR TITLE
Remove axis label iss35

### DIFF
--- a/Examples/TestCases/TestCase35_RemoveAxes.R
+++ b/Examples/TestCases/TestCase35_RemoveAxes.R
@@ -1,0 +1,9 @@
+mod <- dsmodel(function(x,y)list(x,y)) + dsrange(5,5)
+mod1 <- dsmodel(function(x,y)list(x+1,y+1)) + dsrange(5,5, 0.5, axes= FALSE)
+mod1 + dsarrows()
+
+mod2 <- dsmodel(function(x,y)list(x+1,y+1)) + dsrange(5,5, 0.5, frame.plot = FALSE)
+mod2 + dsarrows()
+
+mod3 <- dsmodel(function(x,y)list(x+1,y+1)) + dsrange(5,5, 0.5, axes = FALSE, frame.plot = FALSE)
+mod3 + dsarrows()

--- a/R/dscurve.R
+++ b/R/dscurve.R
@@ -206,7 +206,7 @@ dscurveGraph <- function(fun, colors, lwd, n, iters,
         numPoints <- self$n
       self$xValues <-seq(min(model$range$xlim),max(model$range$xlim), length.out = numPoints)
       self$xValues <- self$prune(self$xlim,self$xValues)
-      self$yValues <- self$fun(self$xValues)
+      self$yValues <- mapply(self$fun,self$xValues)
       self$calculateImage(model, self$xValues, self$yValues)
     },
     render = function(self, model) {

--- a/R/dscurve.R
+++ b/R/dscurve.R
@@ -97,8 +97,8 @@
 #'  curve2
 #'
 #' @export
-dscurve <- function(fun, yfun = "",
-                    col = "black", image = "",
+dscurve <- function(fun, yfun = NULL,
+                    col = "black", image = c(),
                     lwd = 3, n=NULL, iters = 0,
                     crop = TRUE,  tstart=0, tend=1,
                     discretize=FALSE, xlim = NULL,

--- a/R/dscurve.R
+++ b/R/dscurve.R
@@ -98,7 +98,7 @@
 #'
 #' @export
 dscurve <- function(fun, yfun = NULL,
-                    col = "black", image = c(),
+                    col = "black", image = NULL,
                     lwd = 3, n=NULL, iters = 0,
                     crop = TRUE,  tstart=0, tend=1,
                     discretize=FALSE, xlim = NULL,

--- a/R/dsrange.R
+++ b/R/dsrange.R
@@ -19,6 +19,8 @@
 #'  specifies the distance between each point.
 #'  This becomes the default when displaying \code{\link{dsarrows}} or \code{\link{dsdots}}.
 #'  The number of points in the field is defined by:
+#' @param axes If \code{FALSE}, the axes will not be drawn. Defaults to \code{TRUE}.
+#' @param frame.plot If \code{FALSE}, the frame of the plot will not be drawn. Defaults to \code{TRUE}.
 #'  \deqn{(xmax-xmin+1)(ymax-ymin+1)/discretize.}{ascii}
 # @param originOffset Currently not supported. Allows you to place an xlim and ylim
 #  for the graph without including extra discretized space.
@@ -41,7 +43,7 @@
 #' model + dsrange(3, 3, discretize = .09)
 dsrange <- function(x,y,discretize = 0,
                     #originOffset = c(-.1,-.1),
-                    renderCount=101, ...){ # Range
+                    renderCount=101, axes = TRUE, frame.plot = TRUE, ...){ # Range
 
   if(length(x) == 1) {
     x <- c(0,x)
@@ -57,7 +59,6 @@ dsrange <- function(x,y,discretize = 0,
   if(length(ylim)>1) {
     ylim <- c(min(ylim),max(ylim))
   }
-
   if(discretize != 0)
   {
 
@@ -79,10 +80,13 @@ dsrange <- function(x,y,discretize = 0,
       appliedFun = list(),
       xlim = xlim, ylim=ylim, renderCount=renderCount,
       rendered = FALSE,
+      axes = axes,
+      frame.plot = frame.plot,
       render = function(self, model) {
         self$rendered = TRUE
-         plot(0, type = "l", lwd = 3, axes=T, main = model$title,
-             xlab = "", ylab = "", xlim = self$xlim, ylim = self$ylim)
+         plot(0, type = "l", lwd = 3, axes=self$axes, main = model$title,
+             xlab = "", ylab = "", xlim = self$xlim, ylim = self$ylim,
+             frame.plot = self$frame.plot)
       },
 
       recalculate = function(self, model) {
@@ -109,12 +113,14 @@ dsrange <- function(x,y,discretize = 0,
       xlim = xlim, ylim=ylim,
       discretize = 0, renderCount=renderCount,
       rendered = FALSE,
+      axes = axes,
+      frame.plot = frame.plot,
       render = function(self, model) {
         self$rendered = TRUE
-        plot(0, type = "l", lwd = 3, axes=T, main = model$title,
-             xlab = "", ylab = "", xlim = self$xlim, ylim = self$ylim)
-      },
-      ...=...)
+        plot(0, type = "l", lwd = 3, axes=self$axes, main = model$title,
+             xlab = "", ylab = "", xlim = self$xlim, ylim = self$ylim,
+             frame.plot = self$frame.plot)
+      })
   }
   range
 }


### PR DESCRIPTION
This merge will allow the user to set two new inputs, `axes` and `plot.frame`, in `dsrange` to `NULL` to suppress certain visuals regarding the plot frame.
A minor fix, included: `dscurve` no longer defaults `yfun` and `image` to empty strings, but instead to `NULL`.